### PR TITLE
 flake: fix packages output ; bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ We recommend to integrate this repo using Flakes:
   linuxPackages_hdr # recommended option: chaotic.linux_hdr.specialisation.enable
   mesa-git # recommended option: chaotic.mesa-git.enable
   mesa-git-32 # only x86, recommended option: chaotic.mesa-git.enable
+  sway-unwrapped-git
+  sway-git
   waynergy-git
+  wlroots-git
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ We recommend to integrate this repo using Flakes:
 ]
 ```
 
+## Running packages
+
+Besides using our module/overlay, you can run packages using:
+
+```sh
+nix run github:chaotic-aur/nyx#input-leap-git
+```
+
 ## List of options
 
 ```nix

--- a/flake.lock
+++ b/flake.lock
@@ -37,11 +37,11 @@
     "mesa-git-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1680122170,
-        "narHash": "sha256-CJooUewwsmcGe15oq6J/MZKJfmftmLmmIxC2tNJovNU=",
+        "lastModified": 1680171271,
+        "narHash": "sha256-N2tBXvFFGLhf0LUBhabdqRhRqKmCSiimnMnPozqD5T8=",
         "owner": "chaotic-aur",
         "repo": "mesa-mirror",
-        "rev": "43dc19f44d93325e7471a0af9b9874516739ef07",
+        "rev": "9c90deefb2356c970520a404375b0e1796df1535",
         "type": "github"
       },
       "original": {
@@ -53,11 +53,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1680030621,
-        "narHash": "sha256-qQa1NeS5Rvk2lgK5lSk986PC6I72yIHejzM8PFu+dHs=",
+        "lastModified": 1680121753,
+        "narHash": "sha256-rB3ZnNodA4o8Rq0sKZ0t/YdY/MRon4V+bW1b20adgr4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "402cc3633cc60dfc50378197305c984518b30773",
+        "rev": "e779e17ebdf3907ce08c75c7c1b2dc8a1c5038c9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -56,7 +56,8 @@
         let
           applyOverlay = prev:
             let
-              final = defaultOverlay (prev // final) prev;
+              overlayFinal = prev // final // { callPackage = prev.newScope final; };
+              final = defaultOverlay overlayFinal prev;
             in
             final;
         in


### PR DESCRIPTION
## :fish: What?

1. Add newer packages to the list in the README;
2. Update `callPackage` scope when in the `packages` outputs;
3. Bump the `flake.lock`.

## :fishing_pole_and_fish: Why?

- (1) It was missing;
- (2) It was unable to find new dependencies;
- (3) Update `mesa-git` and `nixpkgs`.