### PR TITLE
 flake: add hydraJobs output; bump

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,13 +5,13 @@
       "locked": {
         "lastModified": 1679448083,
         "narHash": "sha256-1Ya59k60YmrJ1AWQ3eoWYBFjiz+RENBNc4FxK3GcgIQ=",
-        "owner": "Plagman",
+        "owner": "ValveSoftware",
         "repo": "gamescope",
         "rev": "5d9ecd462e6d5939fc2697509f53bcb6aba7eb92",
         "type": "github"
       },
       "original": {
-        "owner": "Plagman",
+        "owner": "ValveSoftware",
         "ref": "master",
         "repo": "gamescope",
         "type": "github"

--- a/flake.lock
+++ b/flake.lock
@@ -37,11 +37,11 @@
     "mesa-git-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1680171271,
-        "narHash": "sha256-N2tBXvFFGLhf0LUBhabdqRhRqKmCSiimnMnPozqD5T8=",
+        "lastModified": 1680191447,
+        "narHash": "sha256-G+gNRG1nfLg0jHQxqVVn9kwk1mxNdwDX/jo5ihME/HM=",
         "owner": "chaotic-aur",
         "repo": "mesa-mirror",
-        "rev": "9c90deefb2356c970520a404375b0e1796df1535",
+        "rev": "2cc9364c2061fe4a66398678cabf61e3464e4d77",
         "type": "github"
       },
       "original": {
@@ -53,11 +53,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1680121753,
-        "narHash": "sha256-rB3ZnNodA4o8Rq0sKZ0t/YdY/MRon4V+bW1b20adgr4=",
+        "lastModified": 1680151711,
+        "narHash": "sha256-7vMCXF4t7E07C1jDNzLMDXvPDAuDjNFMX3Zin+8nYY4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e779e17ebdf3907ce08c75c7c1b2dc8a1c5038c9",
+        "rev": "e608c90a1cf381dde6ac9e0f085337150f2af3e2",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -38,32 +38,30 @@
     };
   };
 
-  outputs = { nixpkgs, ... }@inputs:
-    let
-      defaultOverlay = import ./overlays { inherit inputs; };
-    in
-    {
-      # I would prefer if we had something stricter, with attribute alphabetical
-      # sorting, and optimized for git's diffing. But this is the closer we have.
-      formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.nixpkgs-fmt;
-      formatter.aarch64-linux = nixpkgs.legacyPackages.aarch64-linux.nixpkgs-fmt;
+  outputs = { nixpkgs, ... }@inputs: rec {
+    # I would prefer if we had something stricter, with attribute alphabetical
+    # sorting, and optimized for git's diffing. But this is the closer we have.
+    formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.nixpkgs-fmt;
+    formatter.aarch64-linux = nixpkgs.legacyPackages.aarch64-linux.nixpkgs-fmt;
 
-      overlays.default = defaultOverlay;
+    overlays.default = import ./overlays { inherit inputs; };
 
-      nixosModules.default = import ./modules { inherit inputs; };
+    nixosModules.default = import ./modules { inherit inputs; };
 
-      packages =
-        let
-          applyOverlay = prev:
-            let
-              overlayFinal = prev // final // { callPackage = prev.newScope final; };
-              final = defaultOverlay overlayFinal prev;
-            in
-            final;
-        in
-        {
-          x86_64-linux = applyOverlay nixpkgs.legacyPackages.x86_64-linux;
-          aarch64-linux = applyOverlay nixpkgs.legacyPackages.aarch64-linux;
-        };
-    };
+    packages =
+      let
+        applyOverlay = prev:
+          let
+            overlayFinal = prev // final // { callPackage = prev.newScope final; };
+            final = overlays.default overlayFinal prev;
+          in
+          final;
+      in
+      {
+        x86_64-linux = applyOverlay nixpkgs.legacyPackages.x86_64-linux;
+        aarch64-linux = applyOverlay nixpkgs.legacyPackages.aarch64-linux;
+      };
+
+    hydraJobs.default = packages;
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
     };
 
     gamescope-git-src = {
-      url = "github:Plagman/gamescope/master";
+      url = "github:ValveSoftware/gamescope/master";
       flake = false;
     };
 


### PR DESCRIPTION
## :fish: What?

1. Add `hydraJobs` output to `flake.nix`;
2. Move `gamescope-git` to the new upstream repo address;
3. Bump the `flake.lock`.

## :fishing_pole_and_fish: Why?

- (1) I intend to use this as building points;
- (2) https://twitter.com/Plagman2/status/1641239116196237313;
- (3) Update `mesa-git` and `nixpkgs`.

## :fish_cake: Extra

```console
╰─λ nix eval .#hydraJobs.default.aarch64-linux --apply builtins.attrNames
[ "gamescope-git" "input-leap-git" "libei" "linuxPackages_hdr" "linux_hdr" "mesa-git" "mesa-git-32" "sway-git" "sway-unwrapped-git" "waynergy-git" "wlroots-git" ]

╰─λ nix eval .#hydraJobs.default.aarch64-linux.libei --apply builtins.toString
"/nix/store/bafpjjsj79vq4vnq951l5klzdj6wvqsg-libei-0.4.1"
```