### PR TITLE
overlay: use prev for everything that uses override

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,3 +1,7 @@
+# - Sort packages in alphabetic order.
+# - If the recipe uses `override` or `overrideAttrs`, then use `prev`,
+#   otherwise use `final`.
+
 { inputs }: final: prev:
 let
   utils = import ../shared/utils.nix {
@@ -5,12 +9,13 @@ let
   };
 in
 {
-  gamescope-git = final.callPackage ../pkgs/gamescope-git {
+  gamescope-git = prev.callPackage ../pkgs/gamescope-git {
     inherit (inputs) gamescope-git-src;
   };
 
-  input-leap-git = final.callPackage ../pkgs/input-leap-git {
+  input-leap-git = prev.callPackage ../pkgs/input-leap-git {
     inherit (inputs) input-leap-git-src;
+    inherit (final) libei;
     qttools = final.libsForQt5.qt5.qttools;
   };
 
@@ -25,25 +30,25 @@ in
 
   linuxPackages_hdr = final.linuxPackagesFor final.linux_hdr;
 
-  mesa-git = final.callPackage ../pkgs/mesa-git { inherit (inputs) mesa-git-src; inherit utils; };
+  mesa-git = prev.callPackage ../pkgs/mesa-git { inherit (inputs) mesa-git-src; inherit utils; };
   mesa-git-32 =
     if final.stdenv.hostPlatform.isLinux && final.stdenv.hostPlatform.isx86 then
-      final.pkgsi686Linux.callPackage ../pkgs/mesa-git { inherit (inputs) mesa-git-src; inherit utils; }
+      prev.pkgsi686Linux.callPackage ../pkgs/mesa-git { inherit (inputs) mesa-git-src; inherit utils; }
     else throw "No mesa-git-32 for non-x86";
 
-  sway-unwrapped-git = (final.sway-unwrapped.override {
+  sway-unwrapped-git = (prev.sway-unwrapped.override {
     wlroots_0_16 = final.wlroots-git;
   }).overrideAttrs (_: {
     version = "1.9-unstable";
     src = inputs.sway-git-src;
   });
-  sway-git = final.sway.override {
+  sway-git = prev.sway.override {
     sway-unwrapped = final.sway-unwrapped-git;
   };
 
-  waynergy-git = final.waynergy.overrideAttrs (_: { src = inputs.waynergy-git-src; });
+  waynergy-git = prev.waynergy.overrideAttrs (_: { src = inputs.waynergy-git-src; });
 
-  wlroots-git = final.callPackage ../pkgs/wlroots-git {
+  wlroots-git = prev.callPackage ../pkgs/wlroots-git {
     inherit (inputs) wlroots-git-src;
   };
 }


### PR DESCRIPTION
## :fish: What?

If the recipe uses `override` or `overrideAttrs`, then use `prev`, otherwise use `final`.

## Why?

To help some users by avoiding infinite recursions.