### PR TITLE
beautyline-icons: init at unstable-2023-04-02

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ We recommend to integrate this repo using Flakes:
 
 ```nix
 [
+  beautyline-icons # Garuda Linux's verison
   gamescope-git
   input-leap-git
   libei

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,7 +1,6 @@
 # - Sort packages in alphabetic order.
 # - If the recipe uses `override` or `overrideAttrs`, then use `prev`,
 #   otherwise use `final`.
-
 { inputs }: final: prev:
 let
   utils = import ../shared/utils.nix {
@@ -9,6 +8,8 @@ let
   };
 in
 {
+  beautyline-icons = final.callPackage ../pkgs/beautyline-icons { };
+
   gamescope-git = prev.callPackage ../pkgs/gamescope-git {
     inherit (inputs) gamescope-git-src;
   };
@@ -35,18 +36,27 @@ in
 
   linuxPackages_hdr = final.linuxPackagesFor final.linux_hdr;
 
-  mesa-git = prev.callPackage ../pkgs/mesa-git { inherit (inputs) mesa-git-src; inherit utils; };
+  mesa-git = prev.callPackage ../pkgs/mesa-git {
+    inherit (inputs) mesa-git-src;
+    inherit utils;
+  };
   mesa-git-32 =
-    if final.stdenv.hostPlatform.isLinux && final.stdenv.hostPlatform.isx86 then
-      prev.pkgsi686Linux.callPackage ../pkgs/mesa-git { inherit (inputs) mesa-git-src; inherit utils; }
+    if final.stdenv.hostPlatform.isLinux && final.stdenv.hostPlatform.isx86
+    then
+      prev.pkgsi686Linux.callPackage ../pkgs/mesa-git
+        {
+          inherit (inputs) mesa-git-src;
+          inherit utils;
+        }
     else throw "No mesa-git-32 for non-x86";
 
-  sway-unwrapped-git = (prev.sway-unwrapped.override {
-    wlroots_0_16 = final.wlroots-git;
-  }).overrideAttrs (_: {
-    version = "1.9-unstable";
-    src = inputs.sway-git-src;
-  });
+  sway-unwrapped-git =
+    (prev.sway-unwrapped.override {
+      wlroots_0_16 = final.wlroots-git;
+    }).overrideAttrs (_: {
+      version = "1.9-unstable";
+      src = inputs.sway-git-src;
+    });
   sway-git = prev.sway.override {
     sway-unwrapped = final.sway-unwrapped-git;
   };

--- a/pkgs/beautyline-icons/default.nix
+++ b/pkgs/beautyline-icons/default.nix
@@ -1,0 +1,59 @@
+{ breeze-icons
+, fetchFromGitLab
+, gnome-icon-theme
+, gtk3
+, hicolor-icon-theme
+, jdupes
+, lib
+, mint-x-icons
+, pantheon
+, stdenvNoCC
+,
+}:
+stdenvNoCC.mkDerivation rec {
+  pname = "BeautyLine";
+  version = "unstable-2023-04-02";
+
+  src = fetchFromGitLab {
+    owner = "garuda-linux/themes-and-settings/artwork";
+    repo = "beautyline";
+    rev = "24052efcb887a58721ffef731181af65ee81b3c1";
+    sha256 = "sha256-6Nt7m/P0WUjoOetWLrh6pgkyg7FSLg1hGURgKgy6zdc=";
+  };
+
+  sourceRoot = "${src.name}";
+
+  nativeBuildInputs = [ jdupes gtk3 ];
+
+  # ubuntu-mono is also required but missing in ubuntu-themes (please add it if it is packaged at some point)
+  propagatedBuildInputs = [
+    breeze-icons
+    gnome-icon-theme
+    hicolor-icon-theme
+    mint-x-icons
+    pantheon.elementary-icon-theme
+  ];
+
+  dontDropIconThemeCache = true;
+
+  dontPatchELF = true;
+  dontRewriteSymlinks = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/icons/${pname}
+    cp -r * $out/share/icons/${pname}/
+    rm -rf $out/share/icons/${pname}/{.gitignore,README.md,ReadMe}
+    gtk-update-icon-cache $out/share/icons/${pname}
+    jdupes --link-soft --recurse $out/share
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "BeautyLine icon theme mixed with Sweet icons";
+    homepage = "https://gitlab.com/garuda-linux/themes-and-settings/artwork/beautyline";
+    license = lib.licenses.gpl3;
+    maintainers = [ "dr460nf1r3" ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/beautyline-icons/default.nix
+++ b/pkgs/beautyline-icons/default.nix
@@ -21,7 +21,7 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-6Nt7m/P0WUjoOetWLrh6pgkyg7FSLg1hGURgKgy6zdc=";
   };
 
-  sourceRoot = "${src.name}";
+  sourceRoot = "${pname}";
 
   nativeBuildInputs = [ jdupes gtk3 ];
 

--- a/pkgs/beautyline-icons/default.nix
+++ b/pkgs/beautyline-icons/default.nix
@@ -16,7 +16,7 @@ stdenvNoCC.mkDerivation rec {
 
   src = fetchFromGitLab {
     owner = "garuda-linux/themes-and-settings/artwork";
-    repo = "beautyline";
+    repo = pname;
     rev = "24052efcb887a58721ffef731181af65ee81b3c1";
     sha256 = "sha256-6Nt7m/P0WUjoOetWLrh6pgkyg7FSLg1hGURgKgy6zdc=";
   };

--- a/pkgs/beautyline-icons/default.nix
+++ b/pkgs/beautyline-icons/default.nix
@@ -1,13 +1,11 @@
-{ breeze-icons
-, fetchFromGitLab
+{ fetchFromGitLab
 , gnome-icon-theme
 , gtk3
 , hicolor-icon-theme
 , jdupes
 , lib
-, mint-x-icons
-, pantheon
 , stdenvNoCC
+,
 }:
 stdenvNoCC.mkDerivation rec {
   pname = "BeautyLine";
@@ -20,17 +18,11 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-6Nt7m/P0WUjoOetWLrh6pgkyg7FSLg1hGURgKgy6zdc=";
   };
 
-  sourceRoot = "${pname}";
-
   nativeBuildInputs = [ jdupes gtk3 ];
 
-  # ubuntu-mono is also required but missing in ubuntu-themes (please add it if it is packaged at some point)
   propagatedBuildInputs = [
-    breeze-icons
     gnome-icon-theme
     hicolor-icon-theme
-    mint-x-icons
-    pantheon.elementary-icon-theme
   ];
 
   dontDropIconThemeCache = true;
@@ -42,7 +34,7 @@ stdenvNoCC.mkDerivation rec {
     runHook preInstall
     mkdir -p $out/share/icons/${pname}
     cp -r * $out/share/icons/${pname}/
-    rm $out/share/icons/${pname}/{.gitignore,README.md,ReadMe}
+    rm $out/share/icons/${pname}/{README.md,ReadMe}
     gtk-update-icon-cache $out/share/icons/${pname}
     jdupes --link-soft --recurse $out/share
     runHook postInstall

--- a/pkgs/beautyline-icons/default.nix
+++ b/pkgs/beautyline-icons/default.nix
@@ -8,7 +8,6 @@
 , mint-x-icons
 , pantheon
 , stdenvNoCC
-,
 }:
 stdenvNoCC.mkDerivation rec {
   pname = "BeautyLine";

--- a/pkgs/beautyline-icons/default.nix
+++ b/pkgs/beautyline-icons/default.nix
@@ -42,7 +42,7 @@ stdenvNoCC.mkDerivation rec {
     runHook preInstall
     mkdir -p $out/share/icons/${pname}
     cp -r * $out/share/icons/${pname}/
-    rm -rf $out/share/icons/${pname}/{.gitignore,README.md,ReadMe}
+    rm $out/share/icons/${pname}/{.gitignore,README.md,ReadMe}
     gtk-update-icon-cache $out/share/icons/${pname}
     jdupes --link-soft --recurse $out/share
     runHook postInstall

--- a/pkgs/beautyline-icons/default.nix
+++ b/pkgs/beautyline-icons/default.nix
@@ -18,7 +18,7 @@ stdenvNoCC.mkDerivation rec {
     owner = "garuda-linux/themes-and-settings/artwork";
     repo = pname;
     rev = "24052efcb887a58721ffef731181af65ee81b3c1";
-    sha256 = "sha256-6Nt7m/P0WUjoOetWLrh6pgkyg7FSLg1hGURgKgy6zdc=";
+    hash = "sha256-6Nt7m/P0WUjoOetWLrh6pgkyg7FSLg1hGURgKgy6zdc=";
   };
 
   sourceRoot = "${src.name}";


### PR DESCRIPTION
This package most likely can't be upstreamed due to another package already existing. This one however uses another repository as the source and does not contain Candy icons either.