### PR TITLE
applet-window-{appmenu,title}: init at {unstable-2023-04-02,0.7.1}

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ We recommend to integrate this repo using Flakes:
 
 ```nix
 [
-  beautyline-icons # Garuda Linux's verison
+  applet-window-appmenu
+  applet-window-title
+  beautyline-icons # Garuda Linux's version
   gamescope-git
   input-leap-git
   libei

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -8,6 +8,10 @@ let
   };
 in
 {
+  applet-window-appmenu = final.libsForQt5.callPackage ../pkgs/applet-window-appmenu { };
+
+  applet-window-title = final.callPackage ../pkgs/applet-window-title { };
+
   beautyline-icons = final.callPackage ../pkgs/beautyline-icons { };
 
   gamescope-git = prev.callPackage ../pkgs/gamescope-git {

--- a/pkgs/applet-window-appmenu/default.nix
+++ b/pkgs/applet-window-appmenu/default.nix
@@ -1,0 +1,49 @@
+{ cmake
+, extra-cmake-modules
+, fetchFromGitHub
+, kdbusaddons
+, kdecoration
+, kirigami2
+, lib
+, libSM
+, libxcb
+, plasma-framework
+, plasma-workspace
+, stdenv
+, wrapQtAppsHook
+,
+}:
+stdenv.mkDerivation rec {
+  pname = "applet-window-appmenu";
+  version = "unstable-2023-04-02";
+
+  src = fetchFromGitHub {
+    owner = "psifidotos";
+    repo = pname;
+    rev = "1de99c93b0004b80898081a1acfd1e0be807326a";
+    hash = "sha256-PLlZ2qgdge8o1mZOiPOXSmTQv1r34IUmWTmYFGEzNTI=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    kdbusaddons
+    kdecoration
+    kirigami2
+    libSM
+    libxcb
+    plasma-framework
+    plasma-workspace
+  ];
+
+  meta = with lib; {
+    description = "Plasma 5 applet in order to show the window appmenu";
+    homepage = "https://github.com/psifidotos/applet-window-appmenu";
+    license = licenses.gpl2Plus;
+    maintainers = [ "dr460nf1r3" ];
+  };
+}

--- a/pkgs/applet-window-title/default.nix
+++ b/pkgs/applet-window-title/default.nix
@@ -1,0 +1,34 @@
+{ fetchFromGitHub
+, lib
+, stdenvNoCC
+,
+}:
+stdenvNoCC.mkDerivation rec {
+  pname = "applet-window-title";
+  version = "0.7.1";
+
+  src = fetchFromGitHub {
+    owner = "psifidotos";
+    repo = pname;
+    rev = version;
+    hash = "sha256-KybioiBzSxy15f9BD8CDlAuROygeUuYeQBsN4/UwxgY=";
+  };
+
+  propagatedBuildInputs = [ ];
+
+  installPhase = ''
+    runHook preInstall
+    install -d $out/share/plasma/plasmoids/org.kde.windowtitle
+    cp -r * $out/share/plasma/plasmoids/org.kde.windowtitle
+    rm $out/share/plasma/plasmoids/org.kde.windowtitle/{CHANGELOG.md,LICENSE,README.md}
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Plasma 5 applet that shows the application title and icon for active window";
+    homepage = "https://github.com/psifidotos/applet-window-title";
+    license = licenses.gpl2Plus;
+    maintainers = [ "dr460nf1r3" ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
While things aren't upstreamed yet, it would be nice to have these available and prebuilt. (yes, I ran `nix fmt .` before pushing)