### PR TITLE
dr460nized-kde-theme: init at unstable-2023-04-02

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ We recommend to integrate this repo using Flakes:
   applet-window-title
   beautyline-icons # Garuda Linux's version
   firedragon
+  dr460nized-kde-theme
   gamescope-git
   input-leap-git
   libei

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -22,6 +22,8 @@ in
     inherit (final.firedragon-unwrapped) extraPrefsFiles extraPoliciesFiles;
     libName = "firedragon";
   };
+  
+  dr460nized-kde-theme = final.callPackage ../pkgs/dr460nized-kde-theme { };
 
   gamescope-git = prev.callPackage ../pkgs/gamescope-git {
     inherit (inputs) gamescope-git-src;

--- a/pkgs/dr460nized-kde-theme/default.nix
+++ b/pkgs/dr460nized-kde-theme/default.nix
@@ -1,0 +1,37 @@
+{ beautyline-icons
+, fetchFromGitLab
+, lib
+, stdenvNoCC
+, sweet-nova
+,
+}:
+stdenvNoCC.mkDerivation rec {
+  pname = "dr460nized-kde-theme";
+  version = "unstable-2023-04-02";
+
+  src = fetchFromGitLab {
+    owner = "garuda-linux/themes-and-settings/settings";
+    repo = "garuda-dr460nized";
+    rev = "50dfcb081d3bc304ab16e98e2dd8168b11a9e017";
+    sha256 = "sha256-73QxPtfoCGaV2g6A/IeKebakKLcyRMcX1WQnVGPTTAA=";
+  };
+
+  buildInputs = [ beautyline-icons sweet-nova ];
+
+  installPhase = ''
+    runHook preInstall
+    install -d $out/share
+    cp -r usr/share/plasma $out/share/
+    install -d $out/share/icons/dr460nized
+    cp -r usr/share/icons/garuda/* $out/share/icons/dr460nized
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "The default Garuda dr460nized theme";
+    homepage = "https://gitlab.com/garuda-linux/themes-and-settings/settings/garuda-dr460nized";
+    license = licenses.gpl3Only;
+    maintainers = [ "dr460nf1r3" ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
This is pretty much the Sweet KDE theme, tweaked to fit the dr460nized setup best (as seen in Garuda Linux). It depends on `sweet-nova`.