### PR TITLE
ananicy-cpp-rules: init at unstable-2023-03-31

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.env
 result
 result-*

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ We recommend to integrate this repo using Flakes:
 
 ```nix
 [
+  ananicy-cpp-rules
   applet-window-appmenu
   applet-window-title
   beautyline-icons # Garuda Linux's version

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -8,6 +8,8 @@ let
   };
 in
 {
+  ananicy-cpp-rules = final.callPackage ../pkgs/ananicy-cpp-rules { };
+
   applet-window-appmenu = final.libsForQt5.callPackage ../pkgs/applet-window-appmenu { };
 
   applet-window-title = final.callPackage ../pkgs/applet-window-title { };

--- a/pkgs/ananicy-cpp-rules/default.nix
+++ b/pkgs/ananicy-cpp-rules/default.nix
@@ -1,0 +1,32 @@
+{ fetchFromGitHub
+, lib
+, stdenvNoCC
+,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "ananicy-cpp-rules";
+  version = "unstable-2023-03-31";
+
+  src = fetchFromGitHub {
+    owner = "CachyOS";
+    repo = "ananicy-rules";
+    rev = "973c537e7b7e89e8ce8e699e5a8c651c0fc778fa";
+    hash = "sha256-qOMi9QXgs9QUocquzozrAFuuW/UZ3qp3VOgw0a2fx34=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    install -d $out/etc/ananicy.d
+    cp -r * $out/etc/ananicy.d
+    rm $out/etc/ananicy.d/README.md
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "CachyOS' ananicy-rules meant to be used with ananicy-cpp";
+    homepage = "https://github.com/CachyOS/ananicy-rules";
+    license = licenses.gpl3;
+    maintainers = [ "dr460nf1r3" ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
There is no ruleset for `ananicy-cpp`, therefore this provides them. It's explicitly meant for `ananicy-cpp` as rulesets aren't 100% compatible.