### PR TITLE
gamescope-session: init (with HDR support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ nix run github:chaotic-aur/nyx#input-leap-git
 {
   chaotic.mesa-git.enable = true;
   chaotic.linux_hdr.specialisation.enable = true;
+  chaotic.gamescope = {
+    enable = true;
+    package = pkgs.gamescope-git;
+    capSysNice = true;
+    args = [ "--rt" "--prefer-vk-device 8086:9bc4" ];
+    env = { "__GLX_VENDOR_LIBRARY_NAME" = "nvidia" };
+    session.enable = true;
+  };
 }
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
 
     overlays.default = import ./overlays { inherit inputs; };
 
-    nixosModules.default = import ./modules { inherit inputs; };
+    nixosModules = import ./modules { inherit inputs; };
 
     packages =
       let

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,54 +1,13 @@
-{ inputs }: { config, lib, pkgs, ... }:
-let
-  cfg = config.chaotic;
-in
-{
-  options = {
-    chaotic.mesa-git.enable =
-      lib.mkOption {
-        default = false;
-        internal = true;
-        description = ''
-          Whether to use latest Mesa drivers.
-        '';
-      };
-    chaotic.linux_hdr.specialisation.enable =
-      lib.mkOption {
-        default = false;
-        internal = true;
-        description = ''
-          Adds an specialisation for booting with linux_hdr.
-        '';
-      };
+{ inputs, ... }@fromFlakes:
+rec {
+  default = { ... }: {
+    config = {
+      nixpkgs.overlays = [ inputs.self.overlays.default ];
+    };
+
+    imports = [ gamescope linux_hdr mesa_git ];
   };
-  config = {
-    nixpkgs.overlays = [ inputs.self.overlays.default ];
-
-    hardware.opengl = lib.mkIf cfg.mesa-git.enable {
-      package = pkgs.mesa-git.drivers;
-      package32 = lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && pkgs.stdenv.hostPlatform.isx86) pkgs.mesa-git-32.drivers;
-      extraPackages = [ pkgs.mesa-git.opencl ];
-    };
-
-    specialisation.stable-mesa = lib.mkIf cfg.mesa-git.enable {
-      configuration = {
-        system.nixos.tags = [ "stable-mesa" ];
-        hardware.opengl.package = lib.mkForce pkgs.mesa.drivers;
-        hardware.opengl.package32 = lib.mkForce pkgs.pkgsi686Linux.mesa.drivers;
-      };
-    };
-
-    specialisation.hdr = lib.mkIf cfg.linux_hdr.specialisation.enable {
-      configuration = {
-        system.nixos.tags = [ "hdr" ];
-        boot.kernelPackages = lib.mkForce pkgs.linuxPackages_hdr;
-        environment.variables =
-          {
-            DXVK_HDR = "1";
-            ENABLE_GAMESCOPE_WSI = "1";
-          };
-        # TODO: programs.gamescope.args = lib.mkForce [ "--rt" "--hdr-enabled" ];
-      };
-    };
-  };
+  gamescope = import ./gamescope.nix fromFlakes;
+  linux_hdr =  import ./linux_hdr.nix fromFlakes;
+  mesa_git = import ./mesa-git.nix fromFlakes;
 }

--- a/modules/gamescope.nix
+++ b/modules/gamescope.nix
@@ -6,11 +6,11 @@ _:
 , ...
 }:
 with lib; let
-  cfg = config.programs.gamescope;
+  cfg = config.chaotic.gamescope;
   cfgSteam = config.programs.steam;
 in
 {
-  options.programs.gamescope = {
+  options.chaotic.gamescope = {
     enable = mkEnableOption (mdDoc "gamescope");
 
     package = mkOption {
@@ -106,7 +106,7 @@ in
         lib.optional (cfg.enable) gamescope-wrapped
         ++ lib.optional cfg.session.enable gamescopeSessionStarter;
 
-      programs.gamescope.enable = lib.mkDefault cfg.session.enable;
+      chaotic.gamescope.enable = lib.mkDefault cfg.session.enable;
       programs.steam.enable = lib.mkDefault cfg.session.enable;
 
       services.xserver.displayManager.sessionPackages = lib.mkIf cfg.session.enable [ gamescopeSessionFile ];

--- a/modules/gamescope.nix
+++ b/modules/gamescope.nix
@@ -1,0 +1,115 @@
+# Totally based on nrdxp modules
+{ config
+, lib
+, pkgs
+, ...
+}:
+with lib; let
+  cfg = config.programs.gamescope;
+  cfgSteam = config.programs.steam;
+in
+{
+  options.programs.gamescope = {
+    enable = mkEnableOption (mdDoc "gamescope");
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.gamescope;
+      defaultText = literalExpression "pkgs.gamescope";
+      description = mdDoc ''
+        The GameScope package to use.
+      '';
+    };
+
+    capSysNice = mkOption {
+      type = types.bool;
+      default = false;
+      description = mdDoc ''
+        Add cap_sys_nice capability to the GameScope binary.
+      '';
+    };
+
+    args = mkOption {
+      type = types.listOf types.string;
+      default = [ ];
+      example = [ "--rt" "--prefer-vk-device 8086:9bc4" ];
+      description = mdDoc ''
+        Arguments passed to GameScope on startup.
+      '';
+    };
+
+    env = mkOption {
+      type = types.attrsOf types.string;
+      default = { };
+      example = literalExpression ''
+        # for Prime render offload on Nvidia laptops.
+        # Also requires `hardware.nvidia.prime.offload.enable`.
+        {
+          __NV_PRIME_RENDER_OFFLOAD = "1";
+          __VK_LAYER_NV_optimus = "NVIDIA_only";
+          __GLX_VENDOR_LIBRARY_NAME = "nvidia";
+        }
+      '';
+      description = mdDoc ''
+        Default environment variables available to the GameScope process, overridable at runtime.
+      '';
+    };
+
+    session = mkOption {
+      description = mdDoc "Run a GameScope driven Steam session from your display-manager";
+      type = types.submodule {
+        options.enable = mkEnableOption (mdDoc "GameScope Session");
+      };
+    };
+  };
+
+  config = 
+    let
+      gamescope-wrapped = callPackage ../pkgs/gamescope-wrapped {
+        gamescope = cfg.package;
+        gamescopeArgs = cfg.args;
+        gamescopeEnv = cfg.env;
+      };
+
+      gamescopeSessionStarter = pkgs.writeShellScriptBin "steam-gamescope" ''
+        ${gamescope-wrapped}/bin/gamescope --steam \
+          -- ${configSteam.package}/bin/steam -tenfoot -pipewire-dmabuf
+      '';
+
+      gamescopeSessionFile = (pkgs.writeTextDir "share/wayland-sessions/steam.desktop" ''
+        [Desktop Entry]
+        Name=Steam
+        Comment=A digital distribution platform
+        Exec=${gamescopeSessionStarter}/bin/steam-gamescope
+        Type=Application
+      '').overrideAttrs (_: { passthru.providedSessions = [ "steam" ]; });
+    in
+    {
+      security.wrappers = lib.mkIf (cfg.enable && cfg.capSysNice) {
+        gamescope = {
+          owner = "root";
+          group = "root";
+          source = "${gamescope-wrapped}/bin/gamescope";
+          capabilities = "cap_sys_nice+pie";
+        };
+        # needed or steam fails
+        bwrap = lib.mkIf cfg.session.enable {
+          owner = "root";
+          group = "root";
+          source = "${pkgs.bubblewrap}/bin/bwrap";
+          setuid = true;
+        };
+      };
+
+      environment.systemPackages =
+        lib.optional (cfg.enable) [gamescope-wrapped]
+        ++ lib.optional cfg.session.enable gamescopeSessionStarter;
+
+      programs.gamescope.enable = lib.mkDefault cfg.session.enable;
+      programs.steam.enable = lib.mkDefault cfg.session.enable;
+
+      services.xserver.displayManager.sessionPackages = lib.mkIf cfg.session.enable [ gamescopeSessionFile ];
+    };
+
+  meta.maintainers = with maintainers; [ pedrohlc ];
+}

--- a/modules/gamescope.nix
+++ b/modules/gamescope.nix
@@ -1,4 +1,5 @@
 # Totally based on nrdxp modules
+_:
 { config
 , lib
 , pkgs
@@ -65,7 +66,7 @@ in
 
   config = 
     let
-      gamescope-wrapped = callPackage ../pkgs/gamescope-wrapped {
+      gamescope-wrapped = pkgs.callPackage ../pkgs/gamescope-wrapped {
         gamescope = cfg.package;
         gamescopeArgs = cfg.args;
         gamescopeEnv = cfg.env;
@@ -73,7 +74,7 @@ in
 
       gamescopeSessionStarter = pkgs.writeShellScriptBin "steam-gamescope" ''
         ${gamescope-wrapped}/bin/gamescope --steam \
-          -- ${configSteam.package}/bin/steam -tenfoot -pipewire-dmabuf
+          -- ${cfgSteam.package}/bin/steam -tenfoot -pipewire-dmabuf
       '';
 
       gamescopeSessionFile = (pkgs.writeTextDir "share/wayland-sessions/steam.desktop" ''
@@ -102,7 +103,7 @@ in
       };
 
       environment.systemPackages =
-        lib.optional (cfg.enable) [gamescope-wrapped]
+        lib.optional (cfg.enable) gamescope-wrapped
         ++ lib.optional cfg.session.enable gamescopeSessionStarter;
 
       programs.gamescope.enable = lib.mkDefault cfg.session.enable;

--- a/modules/linux_hdr.nix
+++ b/modules/linux_hdr.nix
@@ -1,0 +1,30 @@
+{ inputs }: { config, lib, pkgs, ... }:
+let
+  cfg = config.chaotic;
+in
+{
+  options = {
+    chaotic.linux_hdr.specialisation.enable =
+      lib.mkOption {
+        default = false;
+        internal = true;
+        description = ''
+          Adds an specialisation for booting with linux_hdr.
+        '';
+      };
+  };
+  config = {
+    specialisation.hdr = lib.mkIf cfg.linux_hdr.specialisation.enable {
+      configuration = {
+        system.nixos.tags = [ "hdr" ];
+        boot.kernelPackages = lib.mkForce pkgs.linuxPackages_hdr;
+        environment.variables =
+          {
+            DXVK_HDR = "1";
+            ENABLE_GAMESCOPE_WSI = "1";
+          };
+        programs.gamescope.args = [ "--hdr-enabled" ];
+      };
+    };
+  };
+}

--- a/modules/mesa-git.nix
+++ b/modules/mesa-git.nix
@@ -1,0 +1,31 @@
+{ inputs }: { config, lib, pkgs, ... }:
+let
+  cfg = config.chaotic;
+in
+{
+  options = {
+    chaotic.mesa-git.enable =
+      lib.mkOption {
+        default = false;
+        internal = true;
+        description = ''
+          Whether to use latest Mesa drivers.
+        '';
+      };
+  };
+  config = {
+    hardware.opengl = lib.mkIf cfg.mesa-git.enable {
+      package = pkgs.mesa-git.drivers;
+      package32 = lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && pkgs.stdenv.hostPlatform.isx86) pkgs.mesa-git-32.drivers;
+      extraPackages = [ pkgs.mesa-git.opencl ];
+    };
+
+    specialisation.stable-mesa = lib.mkIf cfg.mesa-git.enable {
+      configuration = {
+        system.nixos.tags = [ "stable-mesa" ];
+        hardware.opengl.package = lib.mkForce pkgs.mesa.drivers;
+        hardware.opengl.package32 = lib.mkForce pkgs.pkgsi686Linux.mesa.drivers;
+      };
+    };
+  };
+}

--- a/pkgs/gamescope-wrapped/default.nix
+++ b/pkgs/gamescope-wrapped/default.nix
@@ -2,11 +2,11 @@
 
 let
   argToWrapper =
-    (x: "--add-flags \"${lib.strings.escapeShellArg x}\"");
+    (x: "--add-flags ${lib.strings.escapeShellArg x}");
   args = lib.strings.concatStringsSep " "
     (lib.lists.map argToWrapper gamescopeArgs);
   envToWrapper =
-    (k: v: "--set \"${k}\" \"${lib.strings.escapeShellArg v}\"");
+    (k: v: "--set \"${k}\" ${lib.strings.escapeShellArg v}");
   env = lib.strings.concatStringsSep " "
     (lib.attrsets.mapAttrsToList envToWrapper gamescopeEnv);
 in

--- a/pkgs/gamescope-wrapped/default.nix
+++ b/pkgs/gamescope-wrapped/default.nix
@@ -1,0 +1,28 @@
+{stdenvNoCC, lib, gamescope, gamescopeArgs, gamescopeEnv, makeBinaryWrapper }:
+
+let
+  argToWrapper =
+    (x: "--add-flags \"${lib.strings.escapeShellArg x}\"");
+  args = lib.strings.concatStringsSep " "
+    (lib.lists.map argToWrapper gamescopeArgs);
+  envToWrapper =
+    (k: v: "--set \"${k}\" \"${lib.strings.escapeShellArg v}\"");
+  env = lib.strings.concatStringsSep " "
+    (lib.attrsets.mapAttrsToList envToWrapper gamescopeEnv);
+in
+stdenvNoCC.mkDerivation {
+  name = "gamescope-wrapped";
+  nativeBuildInputs = [makeBinaryWrapper];
+
+  src = gamescope;
+  dontBuild = true;
+
+  installPhase = ''
+    install -d $out/bin
+    makeBinaryWrapper "$src/bin/gamescope" $out/bin/gamescope \
+      ${args} \
+      ${env}
+    # We need the vulkan layers in systemPackages
+    ln -s $src/share $out/share
+  '';
+}


### PR DESCRIPTION
### :fish: What?

Add modules to have `gamescope` and `gamescope-sesion` (gamescope that launches steam and takes the entire TTY for it);


### :fishing_pole_and_fish: Why?

The best gaming experience, HDR powered, out-of-the-box.
