### PR TITLE
flake: 20230411-2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,11 +37,11 @@
     "mesa-git-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1681215125,
-        "narHash": "sha256-kcrJngU6Xbd1OvJr+7cpUS34+wi+2wjFoXN4tDPtrT0=",
+        "lastModified": 1681228106,
+        "narHash": "sha256-YNxB9hhwk1WkOJRB80J+2RSudRprRqotVbdEweRydN4=",
         "owner": "chaotic-aur",
         "repo": "mesa-mirror",
-        "rev": "9ccaf5583f6b9d7182c0e3ab74bd86ca6c739754",
+        "rev": "f9401a515a4cf75dfea99fe0fc579db0ae80d10e",
         "type": "github"
       },
       "original": {
@@ -53,11 +53,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1681124868,
-        "narHash": "sha256-B93QD0zFE6yc7R5F0bwdhY+y7s5UU9nrlhAAw1OA9mI=",
+        "lastModified": 1681215634,
+        "narHash": "sha256-dI0SsSWb7ksK3OtTCf61vdlBhok838aIpwQ2EUM+jhY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "21f48f0d273ef58c46b9b4c14cf5706c72a36e43",
+        "rev": "5a156c2e89c1eca09b40bcdcee86760e0e4d79a9",
         "type": "github"
       },
       "original": {

--- a/pkgs/ananicy-cpp-rules/default.nix
+++ b/pkgs/ananicy-cpp-rules/default.nix
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation {
     description = "CachyOS' ananicy-rules meant to be used with ananicy-cpp";
     homepage = "https://github.com/CachyOS/ananicy-rules";
     license = licenses.gpl3;
-    maintainers = [ "dr460nf1r3" ];
+    maintainers = [ maintainers.dr460nf1r3 ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/applet-window-appmenu/default.nix
+++ b/pkgs/applet-window-appmenu/default.nix
@@ -44,6 +44,6 @@ stdenv.mkDerivation rec {
     description = "Plasma 5 applet in order to show the window appmenu";
     homepage = "https://github.com/psifidotos/applet-window-appmenu";
     license = licenses.gpl2Plus;
-    maintainers = [ "dr460nf1r3" ];
+    maintainers = [ maintainers.dr460nf1r3 ];
   };
 }

--- a/pkgs/applet-window-title/default.nix
+++ b/pkgs/applet-window-title/default.nix
@@ -28,7 +28,7 @@ stdenvNoCC.mkDerivation rec {
     description = "Plasma 5 applet that shows the application title and icon for active window";
     homepage = "https://github.com/psifidotos/applet-window-title";
     license = licenses.gpl2Plus;
-    maintainers = [ "dr460nf1r3" ];
+    maintainers = [ maintainers.dr460nf1r3 ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/beautyline-icons/default.nix
+++ b/pkgs/beautyline-icons/default.nix
@@ -44,7 +44,7 @@ stdenvNoCC.mkDerivation rec {
     description = "BeautyLine icon theme mixed with Sweet icons";
     homepage = "https://gitlab.com/garuda-linux/themes-and-settings/artwork/beautyline";
     license = lib.licenses.gpl3;
-    maintainers = [ "dr460nf1r3" ];
+    maintainers = [ maintainers.dr460nf1r3 ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/firedragon/default.nix
+++ b/pkgs/firedragon/default.nix
@@ -22,7 +22,7 @@ in
     description = "A fork of LibreWolf, focused on being easier to use";
     homepage = "https://github.com/dr460nf1r3/firedragon-browser";
     license = lib.licenses.mpl20;
-    maintainers = [ "dr460nf1r3" ];
+    maintainers = with lib; [ maintainers.dr460nf1r3 ];
     maxSilent = 14400; # 4h, double the default of 7200s (c.f. #129212, #129115)
     platforms = lib.platforms.unix;
   };


### PR DESCRIPTION
Makes `sweet-nova` available. 